### PR TITLE
Rename project to Pacific Northwest Heritage Explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Historic Bainbridge Island App
+# Pacific Northwest Heritage Explorer
 
-This repository contains a full‑stack web application for exploring the people and places of Bainbridge Island, Washington.  
+This repository contains a full‑stack web application for exploring the people and places of the Pacific Northwest.
 It includes a lightweight **Express** back‑end for managing locations, books, images and authentication, as well as a **Next.js** front‑end built with **React** and **Tailwind CSS** for a polished user experience.
 
 ## Features
 
-* **Location Explorer** – browse historic locations on Bainbridge Island. Each location includes a title, description, optional photos and audio narration, a map position, and a curated list of related books.  
-* **Book Library** – view a curated collection of books about Bainbridge Island. Each entry contains an author, ISBN, a cover image from Open Library and a purchase/read link.  
+* **Location Explorer** – browse historic locations across the Pacific Northwest. Each location includes a title, description, optional photos and audio narration, a map position, and a curated list of related books.
+* **Book Library** – view a curated collection of books about the Pacific Northwest. Each entry contains an author, ISBN, a cover image from Open Library and a purchase/read link.
 * **Image Uploads** – administrators can upload photos for locations. Images are automatically resized into three sizes (full, card and thumb) and stored under `server/public/images/`.  
 * **Authentication** – simple JWT‑based login for administrators. Protects POST/PUT/DELETE routes on the API.  
 * **Environment‑driven configuration** – customize allowed CORS origins, admin credentials and secrets via `.env` files.  
@@ -65,7 +65,7 @@ It includes a lightweight **Express** back‑end for managing locations, books, 
 ## File structure
 
 ```
-historical-bainbridge-app/
+pnw-heritage-explorer/
 ├── package.json             # root scripts (dev, build, start)
 ├── server/                  # Express back‑end
 │   ├── index.js             # entry point

--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ The current implementation is intentionally minimal to make it easy to host on p
 * Integrating map display (e.g. Leaflet or Google Maps) using the `lat`/`lng` coordinates on locations.
 * Caching responses and adding rate limiting for improved performance and security.
 
+## Future improvements
+
+The project is a solid starting point, but several enhancements can make it more robust:
+
+* **Require explicit JWT secret** – ensure deployments fail fast when `JWT_SECRET` is not provided instead of falling back to a default value.
+* **Use hashed admin credentials** – replace the plaintext `ADMIN_PASSWORD` with a bcrypt hash checked at login.
+* **Centralize JSON helpers** – move duplicate read/write logic in route files into a shared utility module.
+* **Validate location images** – enforce a shape for `images` objects so each location provides `full`, `card` and `thumb` URLs.
+* **Improve loading states** – add client‑side placeholders or server‑side rendering for a smoother initial page load.
+
 ## License
 
 This project is provided as‑is to illustrate how to structure a small full‑stack app.  You are free to modify and use it for your own purposes.

--- a/client/package.json
+++ b/client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "historical-bainbridge-client",
+  "name": "pnw-heritage-client",
   "version": "1.0.0",
   "private": true,
   "scripts": {

--- a/client/pages/index.js
+++ b/client/pages/index.js
@@ -22,7 +22,7 @@ export default function Home() {
 
   return (
     <main className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-6">Historic Bainbridge Island</h1>
+      <h1 className="text-3xl font-bold mb-6">Pacific Northwest Heritage Explorer</h1>
       {error && <p className="text-red-600 mb-4">{error}</p>}
       <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
         {locations.map((loc) => (

--- a/client/pages/locations/[id].js
+++ b/client/pages/locations/[id].js
@@ -20,7 +20,7 @@ export default function LocationPage({ location, books }) {
   return (
     <main className="container mx-auto px-4 py-8">
       <Head>
-        <title>{location.title} | Historic Bainbridge Island</title>
+        <title>{location.title} | Pacific Northwest Heritage Explorer</title>
         <meta name="description" content={location.description?.slice(0, 150)} />
       </Head>
       <h1 className="text-3xl font-bold mb-4">{location.title}</h1>

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "historical-bainbridge-app",
+  "name": "pnw-heritage-explorer",
   "private": true,
   "version": "1.0.0",
-  "description": "Full stack application for exploring historical sites on Bainbridge Island.",
+  "description": "Full stack application for exploring historical sites across the Pacific Northwest.",
   "scripts": {
     "install:all": "npm install --prefix server && npm install --prefix client",
     "dev": "concurrently \"npm run dev --prefix server\" \"npm run dev --prefix client\"",

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "historical-bainbridge-server",
+  "name": "pnw-heritage-server",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Rename app and documentation to **Pacific Northwest Heritage Explorer**
- Update package metadata for root, server, and client
- Adjust client pages to display the new title

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897d087b1b0832798bca7c7bfe0a847