### PR TITLE
Require explicit JWT secret for auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It includes a lightweight **Express** back‑end for managing locations, books, 
 
    - `ADMIN_EMAIL` – email address used to log in.
    - `ADMIN_PASSWORD` – password used to log in.  **In production you should hash and salt passwords; plaintext is used here only for demonstration.**
-   - `JWT_SECRET` – random string used to sign your JWTs.
+   - `JWT_SECRET` – random string used to sign your JWTs. **This is required; the server will not start without it.**
    - `CORS_ALLOWED_ORIGINS` – comma‑separated list of origins allowed to call the API (e.g. `http://localhost:3000`).  Leave empty to allow all origins.
 
    For the client, open `client/.env.local` and set `NEXT_PUBLIC_API_BASE_URL` to the base URL of your back‑end (e.g. `http://localhost:4000`).

--- a/server/.env.example
+++ b/server/.env.example
@@ -14,8 +14,8 @@ ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=changeme
 
 ## JWT secret
-# A long, random string used to sign JSON Web Tokens for authentication.
-# Change this to a unique value in your `.env` file.
+# (Required) A long, random string used to sign JSON Web Tokens for authentication.
+# Change this to a unique value in your `.env` file. The server will not start without it.
 JWT_SECRET=your-secret-key
 
 ## CORS allowed origins

--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,10 @@ const helmet = require('helmet');
 const cookieParser = require('cookie-parser');
 require('dotenv').config();
 
+if (!process.env.JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
+
 // Route imports
 const authRoutes = require('./routes/auth');
 const locationsRoutes = require('./routes/locations');

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -11,7 +11,7 @@ function requireAuth(req, res, next) {
   }
   const token = header.split(' ')[1];
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
     req.user = decoded;
     next();
   } catch (err) {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -22,7 +22,7 @@ router.post('/login', async (req, res) => {
   }
   const token = jwt.sign(
     { email, role: 'admin' },
-    process.env.JWT_SECRET || 'secret',
+    process.env.JWT_SECRET,
     { expiresIn: '1h' }
   );
   return res.json({ token });


### PR DESCRIPTION
## Summary
- remove hardcoded JWT secret fallback
- enforce JWT_SECRET presence on server startup
- document required JWT_SECRET in setup instructions

## Testing
- `node server/index.js` *(fails when JWT_SECRET is missing)*
- `JWT_SECRET=test node server/index.js & sleep 1; kill $!`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897dd4dbc0c832781bbb838c5fcdaa7