### PR TITLE
Use bcrypt hash for admin password

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It includes a lightweight **Express** back‑end for managing locations, books, 
    Open `server/.env` and set at least the following variables:
 
    - `ADMIN_EMAIL` – email address used to log in.
-   - `ADMIN_PASSWORD` – password used to log in.  **In production you should hash and salt passwords; plaintext is used here only for demonstration.**
+   - `ADMIN_PASSWORD_HASH` – bcrypt hash of the admin password. Generate one with `node server/scripts/generate-password-hash.js <password>`.
    - `JWT_SECRET` – random string used to sign your JWTs.
    - `CORS_ALLOWED_ORIGINS` – comma‑separated list of origins allowed to call the API (e.g. `http://localhost:3000`).  Leave empty to allow all origins.
 
@@ -108,7 +108,7 @@ The original project blended front‑end, back‑end and media processing into a
 
 * A clean separation between server and client folders.  Each has its own `package.json`, making dependency management explicit.
 * JSON‑based persistence for ease of development.  You can later migrate to a relational database without changing the API surface.
-* A simple authentication mechanism to protect administrative actions.  In production, replace plaintext passwords with bcrypt‑hashed values and add refresh tokens as described in the earlier review.
+* A simple authentication mechanism to protect administrative actions. Passwords are stored as bcrypt hashes and you can add refresh tokens for additional security.
 * A dedicated books route and data file.  Book entries now include accurate links and cover images using the Open Library covers API.  This addresses the mismatches and missing images in the original version.
 * Tailwind CSS for rapid styling and responsive design out of the box.
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -8,10 +8,10 @@ PORT=4000
 
 ## Admin credentials
 # These credentials are used by the `/api/auth/login` route.
-# Provide an email and password to log in and obtain a JWT.
-# In production you should store hashed passwords and use a more secure authentication mechanism.
+# Provide an email and bcrypt hash to log in and obtain a JWT.
+# Generate a hash with `node scripts/generate-password-hash.js <password>`.
 ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD=changeme
+ADMIN_PASSWORD_HASH=$2a$10$GYCFXAC18r99UppGs/.Zg.snIqme35hgSZbKuZ1GalayWaZfjsnde
 
 ## JWT secret
 # A long, random string used to sign JSON Web Tokens for authentication.

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "dev": "nodemon index.js",
-    "start": "node index.js"
+    "start": "node index.js",
+    "generate-password-hash": "node scripts/generate-password-hash.js"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,23 +1,25 @@
 const express = require('express');
 const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
 
 const router = express.Router();
 
 /**
  * Simple login endpoint for admin authentication.
- * Configure ADMIN_EMAIL and ADMIN_PASSWORD in your .env file.
+ * Configure ADMIN_EMAIL and ADMIN_PASSWORD_HASH in your .env file.
  * Returns a JWT on successful login that can be used to access protected routes.
  */
 router.post('/login', async (req, res) => {
   const { email, password } = req.body || {};
   const adminEmail = process.env.ADMIN_EMAIL;
-  const adminPassword = process.env.ADMIN_PASSWORD;
-  if (!adminEmail || !adminPassword) {
+  const adminPasswordHash = process.env.ADMIN_PASSWORD_HASH;
+  if (!adminEmail || !adminPasswordHash) {
     return res
       .status(500)
       .json({ message: 'Admin credentials are not configured on the server.' });
   }
-  if (email !== adminEmail || password !== adminPassword) {
+  const passwordMatches = await bcrypt.compare(password || '', adminPasswordHash);
+  if (email !== adminEmail || !passwordMatches) {
     return res.status(401).json({ message: 'Invalid credentials' });
   }
   const token = jwt.sign(

--- a/server/scripts/generate-password-hash.js
+++ b/server/scripts/generate-password-hash.js
@@ -1,0 +1,16 @@
+const bcrypt = require('bcryptjs');
+
+async function main() {
+  const password = process.argv[2];
+  if (!password) {
+    console.error('Usage: node scripts/generate-password-hash.js <password>');
+    process.exit(1);
+  }
+  const hash = await bcrypt.hash(password, 10);
+  console.log(hash);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Store admin password as bcrypt hash in `ADMIN_PASSWORD_HASH`
- Compare submitted password using `bcrypt.compare` in auth route
- Document and script password hash generation

## Testing
- `npm test`
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_6897dd482298832780e1f6a2d4f86ff3