### PR TITLE
feat: refactor JSON data access for books and locations

### DIFF
--- a/server/routes/books.js
+++ b/server/routes/books.js
@@ -1,6 +1,6 @@
 const express = require('express');
-const fs = require('fs').promises;
 const path = require('path');
+const { readJson, writeJson } = require('../utils/jsonStore');
 const { z } = require('zod');
 const { requireAuth } = require('../middleware/auth');
 
@@ -8,14 +8,8 @@ const router = express.Router();
 
 const booksFile = path.join(__dirname, '../data/books.json');
 
-async function readBooks() {
-  const data = await fs.readFile(booksFile, 'utf-8');
-  return JSON.parse(data);
-}
-
-async function writeBooks(data) {
-  await fs.writeFile(booksFile, JSON.stringify(data, null, 2));
-}
+const readBooks = () => readJson(booksFile);
+const writeBooks = (data) => writeJson(booksFile, data);
 
 // List all books
 router.get('/', async (req, res) => {

--- a/server/routes/locations.js
+++ b/server/routes/locations.js
@@ -1,6 +1,6 @@
 const express = require('express');
-const fs = require('fs').promises;
 const path = require('path');
+const { readJson, writeJson } = require('../utils/jsonStore');
 const { z } = require('zod');
 const { requireAuth } = require('../middleware/auth');
 
@@ -9,14 +9,8 @@ const router = express.Router();
 // Path to the JSON file storing location data
 const locationsFile = path.join(__dirname, '../data/locations.json');
 
-async function readLocations() {
-  const data = await fs.readFile(locationsFile, 'utf-8');
-  return JSON.parse(data);
-}
-
-async function writeLocations(data) {
-  await fs.writeFile(locationsFile, JSON.stringify(data, null, 2));
-}
+const readLocations = () => readJson(locationsFile);
+const writeLocations = (data) => writeJson(locationsFile, data);
 
 // GET all locations
 router.get('/', async (req, res) => {

--- a/server/utils/jsonStore.js
+++ b/server/utils/jsonStore.js
@@ -1,0 +1,38 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+// Simple helpers to read and write JSON files with a basic
+// concurrency safeguard: data is written to a temporary file in the
+// same directory and then atomically renamed over the target file.
+
+/**
+ * Read and parse a JSON file.
+ * @param {string} filePath - Absolute path to the JSON file.
+ * @returns {Promise<any>} Parsed JSON content.
+ */
+async function readJson(filePath) {
+  const data = await fs.readFile(filePath, 'utf-8');
+  return JSON.parse(data);
+}
+
+/**
+ * Write data to a JSON file atomically. The write is first directed to a
+ * temporary file which is then renamed over the destination to minimize
+ * race conditions between readers and writers.
+ *
+ * @param {string} filePath - Absolute path to the JSON file.
+ * @param {any} data - Data to serialize as JSON.
+ */
+async function writeJson(filePath, data) {
+  const dir = path.dirname(filePath);
+  const tempPath = path.join(
+    dir,
+    `${path.basename(filePath)}.${Date.now()}-${process.pid}.tmp`
+  );
+
+  await fs.writeFile(tempPath, JSON.stringify(data, null, 2));
+  await fs.rename(tempPath, filePath);
+}
+
+module.exports = { readJson, writeJson };
+


### PR DESCRIPTION
## Summary
- create reusable `jsonStore` helper for reading and writing JSON files atomically
- refactor `books` and `locations` routes to use new helper

## Testing
- `npm test`
- `npm --prefix server test`


------
https://chatgpt.com/codex/tasks/task_e_6897dd4562e883278fd0a2a2ccd35dc0