### PR TITLE
Enforce structured image metadata for locations

### DIFF
--- a/client/pages/index.js
+++ b/client/pages/index.js
@@ -28,10 +28,12 @@ export default function Home() {
         {locations.map((loc) => (
           <Link key={loc.id} href={`/locations/${loc.id}`} className="block">
             <div className="bg-white rounded-2xl shadow-md overflow-hidden hover:shadow-lg transition-shadow">
-              {loc.images && loc.images.card ? (
+              {loc.images?.thumb || loc.images?.card ? (
                 // eslint-disable-next-line @next/next/no-img-element
                 <img
-                  src={`${process.env.NEXT_PUBLIC_API_BASE_URL}/${loc.images.card}`}
+                  src={`${
+                    process.env.NEXT_PUBLIC_API_BASE_URL
+                  }/${loc.images.thumb || loc.images.card}`}
                   alt={loc.title}
                   className="w-full h-48 object-cover"
                 />

--- a/client/pages/locations/[id].js
+++ b/client/pages/locations/[id].js
@@ -17,6 +17,8 @@ export async function getServerSideProps({ params }) {
 
 export default function LocationPage({ location, books }) {
   if (!location) return <div className="p-8">Location not found</div>;
+  const imageSrc =
+    location.images?.full || location.images?.card || location.images?.thumb;
   return (
     <main className="container mx-auto px-4 py-8">
       <Head>
@@ -24,10 +26,10 @@ export default function LocationPage({ location, books }) {
         <meta name="description" content={location.description?.slice(0, 150)} />
       </Head>
       <h1 className="text-3xl font-bold mb-4">{location.title}</h1>
-      {location.images && location.images.full ? (
+      {imageSrc ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img
-          src={`${process.env.NEXT_PUBLIC_API_BASE_URL}/${location.images.full}`}
+          src={`${process.env.NEXT_PUBLIC_API_BASE_URL}/${imageSrc}`}
           alt={location.title}
           className="w-full max-h-[400px] object-cover rounded-2xl mb-6"
         />

--- a/server/routes/locations.js
+++ b/server/routes/locations.js
@@ -50,7 +50,14 @@ router.post('/', requireAuth, async (req, res) => {
     address: z.string().optional().nullable(),
     lat: z.number().optional(),
     lng: z.number().optional(),
-    images: z.any().optional(),
+    images: z
+      .object({
+        full: z.string().nullable(),
+        card: z.string().nullable(),
+        thumb: z.string().nullable(),
+      })
+      .strict()
+      .optional(),
     audio: z.string().optional().nullable(),
     books: z.array(z.string()).optional(),
   });
@@ -79,7 +86,14 @@ router.put('/:id', requireAuth, async (req, res) => {
     address: z.string().optional().nullable(),
     lat: z.number().optional(),
     lng: z.number().optional(),
-    images: z.any().optional(),
+    images: z
+      .object({
+        full: z.string().nullable(),
+        card: z.string().nullable(),
+        thumb: z.string().nullable(),
+      })
+      .strict()
+      .optional(),
     audio: z.string().optional().nullable(),
     books: z.array(z.string()).optional(),
   });


### PR DESCRIPTION
## Summary
- enforce `images` to be an object with `full`, `card`, and `thumb` fields in location create and update handlers
- use thumbnail/card image paths on the client and fall back when full size is absent

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897dd422ef0832780425338e566675d