### PR TITLE
refactor: replace axios with fetch

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,6 @@
     "next": "13.4.19",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "axios": "^1.4.0",
     "tailwindcss": "^3.3.3",
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.24"

--- a/client/pages/index.js
+++ b/client/pages/index.js
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import axios from 'axios';
 
 export default function Home() {
   const [locations, setLocations] = useState([]);
@@ -10,8 +9,9 @@ export default function Home() {
     async function fetchLocations() {
       try {
         const base = process.env.NEXT_PUBLIC_API_BASE_URL || '';
-        const res = await axios.get(`${base}/api/locations`);
-        setLocations(res.data || []);
+        const res = await fetch(`${base}/api/locations`);
+        const data = await res.json();
+        setLocations(data || []);
       } catch (err) {
         console.error(err);
         setError('Failed to load locations');

--- a/client/pages/locations/[id].js
+++ b/client/pages/locations/[id].js
@@ -1,13 +1,12 @@
-import axios from 'axios';
 import Head from 'next/head';
 
 export async function getServerSideProps({ params }) {
   try {
     const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
-    const locRes = await axios.get(`${base}/api/locations/${params.id}`);
-    const location = locRes.data;
-    const booksRes = await axios.get(`${base}/api/books`);
-    const allBooks = booksRes.data || [];
+    const locRes = await fetch(`${base}/api/locations/${params.id}`);
+    const location = await locRes.json();
+    const booksRes = await fetch(`${base}/api/books`);
+    const allBooks = (await booksRes.json()) || [];
     const associated = (location.books || []).map((bid) => allBooks.find((b) => b.id === bid)).filter(Boolean);
     return { props: { location, books: associated } };
   } catch (err) {


### PR DESCRIPTION
## Summary
- replace axios calls with built-in fetch in client pages
- remove axios dependency from client package.json

## Testing
- `npm test`
- `npm test --prefix client`
- `npm run build --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_6897f12857f48327bc0451ac88eeeab7