### PR TITLE
refactor: replace axios with fetch

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,6 @@
     "next": "13.4.19",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "axios": "^1.4.0",
     "tailwindcss": "^3.3.3",
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.24"

--- a/client/pages/index.js
+++ b/client/pages/index.js
@@ -1,24 +1,25 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import axios from 'axios';
 
 export default function Home() {
   const [locations, setLocations] = useState([]);
   const [error, setError] = useState(null);
+  const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
 
   useEffect(() => {
     async function fetchLocations() {
       try {
-        const base = process.env.NEXT_PUBLIC_API_BASE_URL || '';
-        const res = await axios.get(`${base}/api/locations`);
-        setLocations(res.data || []);
+        const res = await fetch(`${apiBase}/api/locations`);
+        if (!res.ok) throw new Error('Network response was not ok');
+        const data = await res.json();
+        setLocations(data || []);
       } catch (err) {
         console.error(err);
         setError('Failed to load locations');
       }
     }
     fetchLocations();
-  }, []);
+  }, [apiBase]);
 
   return (
     <main className="container mx-auto px-4 py-8">
@@ -31,9 +32,7 @@ export default function Home() {
               {loc.images?.thumb || loc.images?.card ? (
                 // eslint-disable-next-line @next/next/no-img-element
                 <img
-                  src={`${
-                    process.env.NEXT_PUBLIC_API_BASE_URL
-                  }/${loc.images.thumb || loc.images.card}`}
+                  src={`${apiBase}/${loc.images.thumb || loc.images.card}`}
                   alt={loc.title}
                   className="w-full h-48 object-cover"
                 />

--- a/client/pages/locations/[id].js
+++ b/client/pages/locations/[id].js
@@ -1,13 +1,12 @@
-import axios from 'axios';
 import Head from 'next/head';
 
 export async function getServerSideProps({ params }) {
   try {
     const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
-    const locRes = await axios.get(`${base}/api/locations/${params.id}`);
-    const location = locRes.data;
-    const booksRes = await axios.get(`${base}/api/books`);
-    const allBooks = booksRes.data || [];
+    const locRes = await fetch(`${base}/api/locations/${params.id}`);
+    const location = await locRes.json();
+    const booksRes = await fetch(`${base}/api/books`);
+    const allBooks = (await booksRes.json()) || [];
     const associated = (location.books || []).map((bid) => allBooks.find((b) => b.id === bid)).filter(Boolean);
     return { props: { location, books: associated } };
   } catch (err) {
@@ -17,6 +16,7 @@ export async function getServerSideProps({ params }) {
 
 export default function LocationPage({ location, books }) {
   if (!location) return <div className="p-8">Location not found</div>;
+  const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
   const imageSrc =
     location.images?.full || location.images?.card || location.images?.thumb;
   return (
@@ -29,7 +29,7 @@ export default function LocationPage({ location, books }) {
       {imageSrc ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img
-          src={`${process.env.NEXT_PUBLIC_API_BASE_URL}/${imageSrc}`}
+          src={`${apiBase}/${imageSrc}`}
           alt={location.title}
           className="w-full max-h-[400px] object-cover rounded-2xl mb-6"
         />
@@ -42,7 +42,7 @@ export default function LocationPage({ location, books }) {
       {location.audio && (
         <div className="mb-6">
           <h2 className="text-xl font-semibold mb-2">Listen</h2>
-          <audio controls src={`${process.env.NEXT_PUBLIC_API_BASE_URL}/${location.audio}`} className="w-full" />
+          <audio controls src={`${apiBase}/${location.audio}`} className="w-full" />
         </div>
       )}
       {books && books.length > 0 && (


### PR DESCRIPTION
## Summary
- replace axios calls with built-in fetch in client pages
- default client API base URL to local server so data loads without env vars
- remove axios dependency from client package.json

## Testing
- `npm test`
- `npm test --prefix client`
- `npm run build --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_6897f12857f48327bc0451ac88eeeab7